### PR TITLE
feat: 增强 VGMdb 音乐条目提取

### DIFF
--- a/src/models/vgmdb.ts
+++ b/src/models/vgmdb.ts
@@ -36,35 +36,17 @@ const creditsSelectors: Selector = {
 
 
 vgmdbModel.itemList.push(
-  // afterGetWikiData 里面
-  // {
-  //   name: '唱片名',
-  //   selector: {
-  //     selector: '#innermain > h1 > [lang=ja]',
-  //   },
-  //   category: 'subject_title',
-  // },
+  // ---- Info table fields ----
   {
-    name: '录音',
+    name: '厂牌',
     selector: [
       {
         ...commonSelectors,
-        keyWord: 'Organizations',
+        keyWord: 'Label',
       },
     ],
+    pipes: ['ti'],
   },
-  /*
-  {
-    name: '目录编号',
-    selector: [
-      {
-        ...commonSelectors,
-        keyWord: 'Catalog Number',
-      },
-    ],
-    pipes: ['t']
-  },
-  */
   {
     name: '条形码',
     selector: [
@@ -73,7 +55,7 @@ vgmdbModel.itemList.push(
         keyWord: 'Barcode',
       },
     ],
-    pipes: ['t']
+    pipes: ['t'],
   },
   {
     name: '发售日期',
@@ -83,10 +65,10 @@ vgmdbModel.itemList.push(
         keyWord: 'Release Date',
         nextSelector: {
           selector: 'a',
-        }
+        },
       },
     ],
-    pipes: ['date']
+    pipes: ['date'],
   },
   {
     name: '价格',
@@ -123,6 +105,7 @@ vgmdbModel.itemList.push(
       },
     ],
   },
+  // ---- Credits fields ----
   {
     name: '艺术家',
     selector: [
@@ -138,7 +121,7 @@ vgmdbModel.itemList.push(
     selector: [
       {
         ...creditsSelectors,
-        keyWord: 'Composer',
+        keyWord: ['Composer', 'Music Written by', 'Composed by', 'Music by'],
       },
     ],
     pipes: ['ti'],
@@ -148,7 +131,7 @@ vgmdbModel.itemList.push(
     selector: [
       {
         ...creditsSelectors,
-        keyWord: ['Lyricist', 'Lyrics'],
+        keyWord: ['Lyricist', 'Lyrics', 'Lyrics Written by', 'Words by'],
       },
     ],
     pipes: ['ti'],
@@ -158,7 +141,74 @@ vgmdbModel.itemList.push(
     selector: [
       {
         ...creditsSelectors,
-        keyWord: 'Arranger',
+        keyWord: ['Arranger', 'Arranged by', 'Arrangement'],
+      },
+    ],
+    pipes: ['ti'],
+  },
+  {
+    name: '声乐',
+    selector: [
+      {
+        ...creditsSelectors,
+        keyWord: ['Vocal', 'Vocals', 'Chorus'],
+      },
+    ],
+    pipes: ['ti'],
+  },
+  // 乐器: handled in afterGetWikiData (multiple credit rows)
+  {
+    name: '录音',
+    selector: [
+      {
+        ...creditsSelectors,
+        keyWord: ['Recording', 'Recording Engineer', 'Recorded by'],
+      },
+    ],
+    pipes: ['ti'],
+  },
+  {
+    name: '混音',
+    selector: [
+      {
+        ...creditsSelectors,
+        keyWord: ['Mixing', 'Mixing Engineer', 'Mixed by'],
+      },
+    ],
+    pipes: ['ti'],
+  },
+  {
+    name: '母带制作',
+    selector: [
+      {
+        ...creditsSelectors,
+        keyWord: ['Mastering', 'Mastering Engineer', 'Mastered by'],
+      },
+    ],
+    pipes: ['ti'],
+  },
+  {
+    name: '制作人',
+    selector: [
+      {
+        ...creditsSelectors,
+        keyWord: [
+          'Producer', 'Executive Producer', 'Music Producer',
+          'Produced by', 'All Songs Produced by',
+        ],
+      },
+    ],
+    pipes: ['ti'],
+  },
+  {
+    name: '插图',
+    selector: [
+      {
+        ...creditsSelectors,
+        keyWord: [
+          'Illustrator', 'Illustration', 'Jacket Design',
+          'Jacket Illustration', 'Cover Art', 'Art Direction',
+        ],
       },
     ],
     pipes: ['ti'],

--- a/src/sites/vgmdb.ts
+++ b/src/sites/vgmdb.ts
@@ -22,6 +22,28 @@ export const vgmdbTools: SiteTools = {
         $div.style.padding = '6px 0';
         $t.parentElement.insertAdjacentElement('afterend', $div);
       }
+
+      // Clean up credits DOM before extraction:
+      // 1. Remove reference markers: <span title="Referenced">*</span>
+      // 2. Remove group affiliations: " (feel)" text nodes after <a> tags
+      const credits = document.querySelector('#collapse_credits');
+      if (credits) {
+        credits
+          .querySelectorAll('span[title="Referenced"]')
+          .forEach((el) => el.remove());
+
+        for (const td of credits.querySelectorAll('tr > td:nth-child(2)')) {
+          for (const node of [...td.childNodes]) {
+            if (node.nodeType === Node.TEXT_NODE) {
+              node.textContent = node.textContent.replace(
+                /\s*\([^)]*\)/g,
+                ''
+              );
+            }
+          }
+        }
+      }
+
       return true;
     },
     async afterGetWikiData(infos: SingleInfo[]) {
@@ -32,11 +54,29 @@ export const vgmdbTools: SiteTools = {
         value: $h1.innerText,
         category: 'subject_title',
       });
+
+      // Alternative titles as aliases
+      const titleSpans = document.querySelectorAll('h1 span.albumtitle');
+      const primaryText = $h1.innerText.trim();
+      const seen = new Set([primaryText]);
+      for (const span of titleSpans) {
+        const text = (span as HTMLElement).textContent
+          .replace(/^\s*\/\s*/, '')
+          .trim();
+        if (text && !seen.has(text)) {
+          res.push({
+            name: '别名',
+            value: text,
+            category: 'alias',
+          });
+          seen.add(text);
+        }
+      }
+
       for (const item of infos) {
         if (item.name === '价格' && item.value.includes('Not for Sale')) {
           continue;
         }
-        // 替换数字
         if (item.name === '版本特性' && /\d+/.test(item.value)) {
           res.push({
             ...item,
@@ -44,50 +84,82 @@ export const vgmdbTools: SiteTools = {
           });
           continue;
         }
-        if (item.name === '目录编号') {
-          res.push({
-            ...item,
-            value: item.value.trim().split(' ')[0].trim(),
-          });
-          continue;
-        }
         res.push(item);
       }
 
-      /*
-      for (const $td of document.querySelectorAll(
-        '#album_infobit_large td:first-child'
-      )) {
-        const label = ($td as HTMLElement).innerText;
-        const links = $td.nextElementSibling.querySelectorAll('a');
-        let value = '';
-        if ($td.nextElementSibling.querySelector('.artistname[lang=ja]')) {
-          value = [...links]
-            .map(
-              (node) => node.querySelector('.artistname[lang=ja]').textContent
-            )
-            .join('、');
-        } else {
-          value = [...links].map((node) => node.innerText).join('、');
-        }
-        let name = '';
-        if (label.includes('Performer')) {
-          name = '艺术家';
-        } else if (label.includes('Composer')) {
-          name = '作曲';
-        } else if (label.includes('Arranger')) {
-          name = '编曲';
-        } else if (label.includes('Lyricist')) {
-          name = '作词';
-        }
-        if (name) {
-          res.push({
-            name,
-            value,
-          });
+      // Publisher (出版方) — only if different from Label
+      const labelValue = infos.find((i) => i.name === '厂牌')?.value || '';
+      const infoTable = document.querySelector('#rightfloat');
+      if (infoTable) {
+        for (const tr of infoTable.querySelectorAll('tr.maincred')) {
+          const labelTd = tr.querySelector('td:first-child');
+          if (labelTd && labelTd.textContent.trim() === 'Publisher') {
+            const valueTd = tr.querySelector('td:nth-child(2)');
+            if (valueTd) {
+              const pubValue = (valueTd as HTMLElement).innerText.trim();
+              if (pubValue && pubValue !== labelValue) {
+                res.push({ name: '出版方', value: pubValue });
+              }
+            }
+          }
         }
       }
-      */
+
+      // Instruments — collect all matching credit rows
+      const instrumentKeywords = /^(Guitars?|Electric Guitars?|Acoustic Guitars?|Bass|Electric Bass|Drums?|Percussion|Piano|Acoustic Piano|Keyboard|Keyboards|Synthesizer|Synth|Violin|Viola|Cello|Strings|Flute|Oboe|Trumpet|Saxophone|Harmonica|All Instruments|All Other Instruments|Instruments)$/i;
+      const creditSection = document.querySelector('#collapse_credits table');
+      if (creditSection) {
+        const instrumentists: string[] = [];
+        for (const tr of creditSection.querySelectorAll(
+          'tr.maincred, tr.extracred'
+        )) {
+          const roleTd = tr.querySelector('td:first-child') as HTMLElement;
+          if (!roleTd) continue;
+          // Use the en span's title for role matching to avoid mixed-language textContent
+          const enSpan = roleTd.querySelector(
+            '.artistname[lang="en"]'
+          ) as HTMLElement;
+          const roleText = enSpan
+            ? (enSpan.title || enSpan.textContent).trim()
+            : roleTd.innerText.trim();
+          if (instrumentKeywords.test(roleText)) {
+            const valueTd = tr.querySelector(
+              'td:nth-child(2)'
+            ) as HTMLElement;
+            if (valueTd) {
+              const names = valueTd.innerText.trim();
+              if (names) instrumentists.push(names);
+            }
+          }
+        }
+        if (instrumentists.length) {
+          res.push({ name: '乐器', value: instrumentists.join('、') });
+        }
+      }
+
+      // Disc count
+      const tracklist = document.querySelector('#tracklist');
+      if (tracklist) {
+        const discHeaders = tracklist.querySelectorAll('.tl b');
+        let discCount = 0;
+        discHeaders.forEach((b) => {
+          if (/^Disc\s+\d+$/i.test(b.textContent.trim())) discCount++;
+        });
+        if (discCount > 0) {
+          res.push({ name: '碟片数量', value: String(discCount) });
+        }
+      }
+
+      // VGMdb link
+      const canonical = document.querySelector(
+        'link[rel="canonical"]'
+      ) as HTMLLinkElement;
+      const vgmdbUrl = canonical?.href || location.href.replace(/\?.*$/, '');
+      if (vgmdbUrl) {
+        res.push({ name: '链接', value: vgmdbUrl, category: 'listItem' });
+      }
+
+      // Cover image
       let url = (
         document.querySelector('meta[property="og:image"]') as HTMLMetaElement
       )?.content;
@@ -118,8 +190,8 @@ export const vgmdbTools: SiteTools = {
           },
         });
       }
-      // 曲目列表
-      const tracklist = document.querySelector('#tracklist');
+
+      // Tracklist (episodes)
       if (tracklist) {
         let tableList = tracklist.querySelectorAll('.tl > table');
         document.querySelectorAll('#tlnav > li > a')?.forEach((item) => {
@@ -139,7 +211,6 @@ export const vgmdbTools: SiteTools = {
         });
         res.push({
           category: 'ep',
-          // 名字留空
           name: '',
           value: discArr,
         });


### PR DESCRIPTION
## 改动内容

- 修复错误的 "Organizations" → 录音 映射，改为从 Recording/Recording Engineer 等 credits 字段提取
- 新增 infobox 字段：厂牌 (Label)、碟片数量、出版方（仅当与厂牌不同时）、别名（其他语言标题）、链接（VGMdb URL）
- 新增 credits 字段：声乐、乐器、录音、混音、母带制作、制作人、插图
- 支持 VGMdb credit 角色变体写法（如 "Music Written by"、"Arranged by"、"Mixed by"、"Mastered by" 等）
- 在 beforeCreate 阶段清理 DOM 噪音：
  - 移除引用标记（`<span title="Referenced">*</span>`）
  - 移除艺术家名后的隶属团体标注（如链接后的 " (feel)"）
- 乐器字段通过 afterGetWikiData 手动收集多行 credit，绕过框架单行匹配的限制

## 测试

- [ ] 标准 credits 专辑页（如 https://vgmdb.net/album/102049）
- [ ] 含变体角色名和引用标记的专辑页（如 https://vgmdb.net/album/3149）
- [ ] 多碟片专辑，验证碟片数量提取
- [ ] 验证出版方仅在与厂牌不同时出现